### PR TITLE
Add min/max hold count functionality

### DIFF
--- a/climbdex/db.py
+++ b/climbdex/db.py
@@ -239,6 +239,21 @@ def get_search_base_sql_and_binds(args):
                 mirrored_holds, match_roles
             )
         sql += " )"
+    
+    maxHolds = args.get("maxHoldNumber")
+    minHolds = args.get("minHoldNumber")
+    if maxHolds or minHolds:
+        sql += " AND (length(frames) - length(replace(frames, 'r' || (SELECT placement_roles.id FROM placement_roles JOIN layouts on layouts.product_id = placement_roles.product_id WHERE layouts.id = $layout_id AND placement_roles.position = '2'), ''))) / 3"
+    if maxHolds and minHolds:
+        sql += " BETWEEN $minHolds and $maxHolds"
+        binds['maxHolds'] = int(maxHolds)
+        binds['minHolds'] = int(minHolds)
+    elif maxHolds:
+        sql += " <= $maxHolds"
+        binds['maxHolds'] = int(maxHolds)
+    elif minHolds:
+        sql += " >= $minHolds"
+        binds['minHolds'] = int(minHolds)
 
     return sql, binds
 

--- a/climbdex/db.py
+++ b/climbdex/db.py
@@ -243,7 +243,7 @@ def get_search_base_sql_and_binds(args):
     maxHolds = args.get("maxHoldNumber")
     minHolds = args.get("minHoldNumber")
     if maxHolds or minHolds:
-        sql += " AND (length(frames) - length(replace(frames, 'r' || (SELECT placement_roles.id FROM placement_roles JOIN layouts on layouts.product_id = placement_roles.product_id WHERE layouts.id = $layout_id AND placement_roles.position = '2'), ''))) / 3"
+        sql += " AND ((length(frames) - length(replace(frames, 'r' || (SELECT placement_roles.id FROM placement_roles JOIN layouts on layouts.product_id = placement_roles.product_id WHERE layouts.id = $layout_id AND placement_roles.position = '2'), ''))) / (length((SELECT placement_roles.id FROM placement_roles JOIN layouts on layouts.product_id = placement_roles.product_id WHERE layouts.id = $layout_id AND placement_roles.position = '2')) + 1))"
     if maxHolds and minHolds:
         sql += " BETWEEN $minHolds and $maxHolds"
         binds['maxHolds'] = int(maxHolds)

--- a/climbdex/static/js/filterSelection.js
+++ b/climbdex/static/js/filterSelection.js
@@ -107,6 +107,36 @@ document
   .getElementById("button-reset-hold-filter")
   .addEventListener("click", resetHoldFilter);
 
+document.getElementById('use-min-holds')
+.addEventListener('change', function() {
+  document.getElementById('input-min-hold-number').disabled = !this.checked
+})
+
+document.getElementById('use-max-holds')
+.addEventListener('change', function() {
+  document.getElementById('input-max-hold-number').disabled = !this.checked
+})
+
+document
+  .getElementById('input-min-hold-number')
+  .addEventListener('change', function(event) {
+    const min = event.target
+    const max = document.getElementById('input-max-hold-number')
+    if (min.value > max.value && !max.disabled) {
+      max.value = min.value
+    }
+  })
+
+document
+.getElementById('input-max-hold-number')
+.addEventListener('change', function(event) {
+  const max = event.target
+  const min = document.getElementById('input-min-hold-number')
+  if (max.value < min.value && !min.disabled) {
+    min.value = max.value
+  }
+})
+
 const backAnchor = document.getElementById("anchor-back");
 backAnchor.href = location.origin;
 if (document.referrer) {

--- a/climbdex/templates/filterSelection.html.j2
+++ b/climbdex/templates/filterSelection.html.j2
@@ -5,7 +5,10 @@
   {% include 'head.html.j2'%}
   <style>
     .input-group-text {
-      width: 150px;
+      width: 170px;
+    }
+    .enableBox {
+      margin-right: .3rem;
     }
   </style>
 </head>
@@ -73,6 +76,16 @@
           <div class="row">
             <div class="col">
               <div class="collapse multi-collapse" id="advanced-filters">
+                <div class="input-group mb-3">
+                  <span class="input-group-text"><input class="enableBox" type="checkbox" id="use-min-holds" name="useMinHolds">Min Hand Holds</span>
+                  <input type="number" , class="form-control" id="input-min-hold-number" disabled="true" value="" min="0" max="30"
+                    step="1" name="minHoldNumber" />
+                </div>
+                <div class="input-group mb-3">
+                  <span class="input-group-text"><input class="enableBox" type="checkbox" id="use-max-holds" name="useMaxHolds">Max Hand Holds</span>
+                  <input type="number" , class="form-control" id="input-max-hold-number" disabled="true" value="" min="1" max="30"
+                    step="1" name="maxHoldNumber" />
+                </div>
                 <div class="input-group mb-3">
                   <span class="input-group-text">Min Rating</span>
                   <input type="number" , class="form-control" id="input-min-rating" value="1.0" min="1.0" max="3.0"


### PR DESCRIPTION
This PR adds the ability to filter by min/max hold count as discussed in #56 

@lemeryfertitta I am not sure that I am retrieving the layout product id (which is then used to get the placement role id) in a efficient way, maybe take a look?

https://github.com/btmccord/Climbdex/blob/b2d0bd38f892a0752d6ea008dd2d351abd373dcb/climbdex/db.py#L246

