### PR TITLE
set angle via url parameter in filter view

### DIFF
--- a/climbdex/templates/filterSelection.html.j2
+++ b/climbdex/templates/filterSelection.html.j2
@@ -40,7 +40,7 @@
           <div class="input-group mb-3">
             <span class="input-group-text">Angle</span>
             <select class="form-select" id="select-angle" name="angle">
-              <option value="any">Any</option>
+              <option value="any" {% if not params.angle %}selected{% endif %}>Any</option>
               {% for angle_option in angles %}
               <option value="{{ angle_option[0] }}" {% if params.angle and params.angle|int == angle_option[0] %}selected{% endif %}>
                 {{ angle_option[0] }}

--- a/climbdex/templates/filterSelection.html.j2
+++ b/climbdex/templates/filterSelection.html.j2
@@ -40,9 +40,11 @@
           <div class="input-group mb-3">
             <span class="input-group-text">Angle</span>
             <select class="form-select" id="select-angle" name="angle">
-              <option value="any" selected>Any</option>
-              {% for angle in angles %}
-              <option value="{{angle[0]}}">{{angle[0]}}</option>
+              <option value="any">Any</option>
+              {% for angle_option in angles %}
+              <option value="{{ angle_option[0] }}" {% if params.angle and params.angle|int == angle_option[0] %}selected{% endif %}>
+                {{ angle_option[0] }}
+              </option>
               {% endfor %}
             </select>
           </div>


### PR DESCRIPTION
Our Tensionboard is normally set to a fixed angle. With the current filter-view you couldn't preselect an angle via URL (for example as bookmark).

This PR selects the angle in /filter if a (valid) param.angle is set in the URL. This allows to bookmark a board URL with angle preselected. Value is only selected if the option is available, otherwise the "any" option stays selected.