### PR TITLE
Fix login modal closing behavior

### DIFF
--- a/climbdex/static/js/boardSelection.js
+++ b/climbdex/static/js/boardSelection.js
@@ -127,6 +127,9 @@ const boardSelect = document.getElementById("select-board");
 boardSelect.addEventListener("change", handleBoardSelection);
 handleBoardSelection();
 
+const modal = new bootstrap.Modal(document.getElementById("div-modal"), {
+  keyboard: false,
+});
 const loginForm = document.getElementById("form-login");
 loginForm.addEventListener("submit", function (event) {
   const username = document.getElementById("input-username").value;
@@ -152,11 +155,20 @@ loginForm.addEventListener("submit", function (event) {
         document.cookie = `${boardName}_login=${JSON.stringify(
           json
         )}; SameSite=Strict; Secure;`;
-        const modal = bootstrap.Modal.getInstance("#div-modal");
         modal.hide();
         populateLoginForm(boardName);
       }
     });
   });
   event.preventDefault();
+});
+
+const loginButton = document.getElementById("button-login");
+loginButton.addEventListener("click", function () {
+  modal.show();
+});
+
+const closeButton = document.getElementById("button-close");
+closeButton.addEventListener("click", function () {
+  modal.hide();
 });

--- a/climbdex/templates/boardSelection.html.j2
+++ b/climbdex/templates/boardSelection.html.j2
@@ -44,9 +44,7 @@
             <select class="form-select" id="select-size" name="size"></select>
           </div>
           <div class="input-group mb-1 d-grid gap-2">
-            <!-- Button trigger modal -->
-            <button id="button-login" type="button" class="btn btn-secondary" data-bs-toggle="modal"
-              data-bs-target="#div-modal" disabled>
+            <button id="button-login" type="button" class="btn btn-secondary">
             </button>
           </div>
           <div class="form-text mb-3" id="div-login-text">
@@ -76,7 +74,7 @@
       <div class="modal-content">
         <div class="modal-header">
           <h1 class="modal-title fs-5" id="header-modal-title"></h1>
-          <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+          <button type="button" id="button-close" class="btn-close"></button>
         </div>
         <form id="form-login">
           <div class="modal-body">


### PR DESCRIPTION
FYI @gardaholm the issue is that you apparently can't mix the `data-bs` close/open with Javascript close/open, so I just switched it to all JS. This should fix the issue you were seeing and we don't need to refresh the whole page with `location.reload()`.