### PR TITLE
isMirroredMode() fix for non mirrored layouts

### DIFF
--- a/climbdex/static/js/results.js
+++ b/climbdex/static/js/results.js
@@ -4,7 +4,7 @@ const colorMap = colors.reduce((acc, colorRow) => {
 }, {});
 
 function isMirroredMode() {
-  return document.getElementById("button-mirror").classList.contains("active");
+  return (document.getElementById("button-mirror")!=null) && (document.getElementById("button-mirror").classList.contains("active"));
 }
 
 function mirrorClimb() {
@@ -333,6 +333,7 @@ function drawResultsPage(results, pageNumber, pageSize, resultsCount) {
       difficultyError,
       classic,
     ] = result;
+    
     const classicSymbol = classic !== null ? "\u00A9" : "";
     const difficultyErrorPrefix = Number(difficultyError) > 0 ? "+" : "-";
     const difficultyErrorSuffix = String(


### PR DESCRIPTION
Was getting null on document.getElementById("button-mirror") and throwing Uncaught TypeError: Cannot read properties of null (reading 'classList'). Wasn't allowing ascents to be logged.