### PR TITLE
Remove Eastern US Timezone

### DIFF
--- a/climbdex/static/js/results.js
+++ b/climbdex/static/js/results.js
@@ -139,7 +139,7 @@ document
       .textContent.includes("©")
       ? true
       : false;
-    const climbed_at = new Date().toLocaleString('sv', { timeZone: 'America/New_York'});
+    const climbed_at = new Date().toLocaleString('sv');
     const comment = document.getElementById("comment").value;
 
     const data = {


### PR DESCRIPTION
Removing Eastern US Timezone conversion from timestamp. Getting local time and formatting instead.