### PR TITLE
Hide logging for other boards

### DIFF
--- a/climbdex/templates/results.html.j2
+++ b/climbdex/templates/results.html.j2
@@ -101,7 +101,7 @@
                 </button>
               </li>
               {% endif %}
-              {% if request.cookies %}
+              {% if login_cookie %}
               <li><button class="dropdown-item" href="#" data-bs-toggle="modal" data-bs-target="#div-log-modal">Log
                   Climb
               </li>

--- a/climbdex/views.py
+++ b/climbdex/views.py
@@ -58,6 +58,7 @@ def results():
         grades=climbdex.db.get_data(board_name, "grades"),
         led_colors=get_led_colors(board_name, layout_id),
         layout_is_mirrored=climbdex.db.layout_is_mirrored(board_name,layout_id),
+        login_cookie=login_cookie,
         **get_draw_board_kwargs(
             board_name,
             layout_id,


### PR DESCRIPTION
When only logged into one board don't show logging capabilities for other boards that aren't signed in. For #95.